### PR TITLE
Stacking to current container including 2 config values

### DIFF
--- a/Extensions.cs
+++ b/Extensions.cs
@@ -34,6 +34,11 @@ namespace QuickerStack
             return Extensions._m_nview.Invoke(instance);
         }
 
+        public unsafe static Container GetCurrentContainer(this InventoryGui instance)
+        {
+            return Extensions._m_currentContainer.Invoke(instance);
+        }
+
         // Token: 0x0600002A RID: 42 RVA: 0x00002B31 File Offset: 0x00000D31
         public static bool XAdd<T>(this List<T> instance, T item)
         {
@@ -54,5 +59,7 @@ namespace QuickerStack
 
         // Token: 0x0400001E RID: 30
         internal static readonly AccessTools.FieldRef<Container, ZNetView> _m_nview = AccessTools.FieldRefAccess<Container, ZNetView>("m_nview");
+
+        internal static readonly AccessTools.FieldRef<InventoryGui, Container> _m_currentContainer = AccessTools.FieldRefAccess<InventoryGui, Container>("m_currentContainer");
     }
 }

--- a/QuickerStack.csproj
+++ b/QuickerStack.csproj
@@ -35,23 +35,23 @@
   <ItemGroup>
     <Reference Include="0Harmony, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\0Harmony.dll</HintPath>
+      <HintPath>Libraries\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="assembly_guiutils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\assembly_guiutils.dll</HintPath>
+      <HintPath>Libraries\assembly_guiutils.dll</HintPath>
     </Reference>
     <Reference Include="assembly_utils, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\assembly_utils.dll</HintPath>
+      <HintPath>Libraries\assembly_utils.dll</HintPath>
     </Reference>
     <Reference Include="assembly_valheim, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\assembly_valheim.dll</HintPath>
+      <HintPath>Libraries\assembly_valheim.dll</HintPath>
     </Reference>
     <Reference Include="BepInEx, Version=5.4.19.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\BepInEx.dll</HintPath>
+      <HintPath>Libraries\BepInEx.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -63,28 +63,28 @@
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\UnityEngine.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.IMGUIModule">
-      <HintPath>..\ValheimLibs\UnityEngine.IMGUIModule.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.IMGUIModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.InputLegacyModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\UnityEngine.InputLegacyModule.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.InputLegacyModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\ValheimLibs\UnityEngine.UI.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.UI.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIElementsNativeModule">
-      <HintPath>..\ValheimLibs\UnityEngine.UIElementsNativeModule.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.UIElementsNativeModule.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UIModule">
-      <HintPath>..\ValheimLibs\UnityEngine.UIModule.dll</HintPath>
+      <HintPath>Libraries\UnityEngine.UIModule.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #7 . I don't think it's necessary to thread the stacking of the current container (which would make fixing the threading bugs even harder). This also makes sure that it's always stacked to first, which is a nice behavior for the player.

Also
- fixed project file hint paths
- fixed ReportResult number parsing

Good luck getting the threading to work. I will delete it from my fork for now and add some things I want like UI. Maybe we can chat regularly about keeping our versions a bit synced, especially for bug fixes. I don't plan to release my fork.